### PR TITLE
Use relative path when zipping ModdingAPI

### DIFF
--- a/Assembly-CSharp/Assembly-CSharp.csproj
+++ b/Assembly-CSharp/Assembly-CSharp.csproj
@@ -276,7 +276,8 @@
             cp "$(ProjectDir)$(OutputPath)/Assembly-CSharp.xml" "$(SolutionDir)/OutputFinal/hollow_knight_Data/Managed/"
 
             echo "Zip the Distribution Folder"
-            zip -r "$(SolutionDir)ModdingAPI.zip" $(SolutionDir)OutputFinal/*
+            cd "$(SolutionDir)/OutputFinal"
+            zip -r "../ModdingAPI.zip" *
         </PostBuildEvent>
     </PropertyGroup>
     <PropertyGroup>


### PR DESCRIPTION
This also stops it from breaking when you are building from a folder with spaces in its full path name. EG 

    /storage/I am dumb and put spaces in folders/HollowKnight.Modding/